### PR TITLE
Added function to get series info

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -4,3 +4,4 @@ BASE_URL = "https://9anime.to"
 SEARCH_URL = BASE_URL + "/search"
 GRABBER_API = BASE_URL + "/grabber-api/"
 INFO_API = BASE_URL + '/ajax/episode/info'
+SERIES_INFO_API = BASE_URL + "/ajax/film/tooltip/"


### PR DESCRIPTION
In this function, either enter the entire link or just the anime series ID, and it will give the related information in the following format - 

`{'title': 'Name of anime', 'year': '(int) Year anime released', 'Scores': 'Anime Score', 'Status': 'Completed/Airing', 'Date aired': 'season air dates', 'Genre': 'genre of the anime', 'Other names': 'other names of anime'}`